### PR TITLE
✨ feat(state): Add useEffect to update the state

### DIFF
--- a/frontend/src/api/state.ts
+++ b/frontend/src/api/state.ts
@@ -81,6 +81,10 @@ export function useEntryState(
   const [state, setState] = useState(selector)
 
   useEffect(() => {
+    setState(selector())
+  }, [selector])
+
+  useEffect(() => {
     const update = () => {
       setState(selector())
     }


### PR DESCRIPTION
Fixed a bug that occurred when using the Yamaha 01V96 mixer.
When switching from the AUX tab to the BUS tab, the fader statuses were not updated.

- Updates the selector state when the selector itself changes.
- Ensures that the component state is always synchronized with the global state.